### PR TITLE
fixed multipolygon error, submask speedup 1700x

### DIFF
--- a/create-custom-coco-dataset.ipynb
+++ b/create-custom-coco-dataset.ipynb
@@ -60,7 +60,7 @@
     "        image = create_image_annotation(original_file_name, w, h, image_id)\n",
     "        images.append(image)\n",
     "\n",
-    "        sub_masks = create_sub_masks(mask_image_open, w, h)\n",
+    "        sub_masks = create_sub_masks(mask_image_open, category_colors.keys())\n",
     "        for color, sub_mask in sub_masks.items():\n",
     "            category_id = category_colors[color]\n",
     "\n",


### PR DESCRIPTION
This pull requests makes 2 contributions:
- addressing the multipolygon problem
- speedup sub mask creation 1700x

This pull request addresses the multipolygon error in issues [9](https://github.com/chrise96/image-to-coco-json-converter/issues/9) and [12](https://github.com/chrise96/image-to-coco-json-converter/issues/12), by adding each individual polygon in the multipolygon. 

The current sub mask creation is very slow because it uses Python loops. This function was reimplemented using NumPy native boolean logic. This implementation receives the category colors instead of the image size. Using cProfile, in our dataset, the speedup was of 1700x.

Contributions by myself and @fsmatilde.


